### PR TITLE
Add option to let the user specify the task name to run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ The max number of child processes to spawn. The default is
 This is a _maximum_ limit. While you _can_ specify a number greater than the
 number of processors in your machine, you won't really see any benefit. Also,
 
+#### `taskName`
+
+We automatically try to get the currently running task name, but this can be hard to do with certain gulp setups. In that case, use this parameter to set the task name.
+
 ### Additional methods
 
 #### `clusterSrc.logfiles()`

--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ module.exports = function (gulp) {
         builder = typeof opts === 'function' ? opts : builder;
         opts = typeof opts === 'function' ? {} : opts;
 
-        const taskName = getRunningTaskName();
+        const taskName = opts.taskName || getRunningTaskName();
 
         if (cluster.isMaster) {
             const workerCount = +(opts.concurrency || os.cpus().length);


### PR DESCRIPTION
This can be useful with certain gulp setups where there are multiple tasks currently running, so we can't auto-determine which one is the correct one to parallelize. In our asset build setup, getRunningTaskName filtered down to a list of about 17 currently running tasks. It then took the first one, which was not the task we were trying to parallelize.